### PR TITLE
Enhancement/1

### DIFF
--- a/awssert/__init__.py
+++ b/awssert/__init__.py
@@ -2,3 +2,5 @@
 
 # TODO: Fix pkg_resources.DistributionNotFound error when running through Github Actions
 # __version__ = pkg_resources.get_distribution("awssert").version
+
+from awssert.hooks import *

--- a/awssert/hooks.py
+++ b/awssert/hooks.py
@@ -5,8 +5,8 @@ from awssert.s3 import register_s3_assertions
 from awssert.dynamodb import register_dynamodb_assertions
 
 
-@pytest.fixture
-def awssert():
+@pytest.hookimpl
+def pytest_runtest_call():
     default_session = boto3._get_default_session()
     default_session.events.register(
         "creating-resource-class.s3.Bucket", register_s3_assertions

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,4 @@ create-wheel = yes
 
 [flake8]
 max-line-length=88
-ignore=F811,F401
+exclude=**/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "pytest",
         "boto3",
     ],
+    entry_points={"pytest11": ["name_of_plugin = awssert"]},
     project_urls={
         "Bug Reports": "https://github.com/TSNoble/awssert/issues",
         "Source": "https://github.com/TSNoble/awssert",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["awssert"]

--- a/test/test_dynamodb.py
+++ b/test/test_dynamodb.py
@@ -1,7 +1,6 @@
 import pytest
 import moto
 import boto3
-from awssert.fixture import awssert
 
 
 @pytest.fixture
@@ -10,7 +9,7 @@ def mock_ddb():
         yield
 
 
-def test_table_empty_assertion(mock_ddb, awssert):
+def test_table_empty_assertion(mock_ddb):
     boto3.client("dynamodb").create_table(
         AttributeDefinitions=[{"AttributeName": "mock", "AttributeType": "S"}],
         TableName="mock",
@@ -22,7 +21,7 @@ def test_table_empty_assertion(mock_ddb, awssert):
     assert table.should_not_be.empty()
 
 
-def test_table_has_item_assertion(mock_ddb, awssert):
+def test_table_has_item_assertion(mock_ddb):
     boto3.client("dynamodb").create_table(
         AttributeDefinitions=[{"AttributeName": "mock", "AttributeType": "S"}],
         TableName="mock",
@@ -38,7 +37,7 @@ def test_table_has_item_assertion(mock_ddb, awssert):
     assert table.does_not_have.item({"mock": "bar"})
 
 
-def test_table_has_key_assertion(mock_ddb, awssert):
+def test_table_has_key_assertion(mock_ddb):
     boto3.client("dynamodb").create_table(
         AttributeDefinitions=[{"AttributeName": "mock", "AttributeType": "S"}],
         TableName="mock",

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -1,7 +1,6 @@
 import pytest
 import moto
 import boto3
-from awssert.fixture import awssert
 
 
 @pytest.fixture
@@ -10,7 +9,7 @@ def mock_s3():
         yield
 
 
-def test_s3_bucket_contains_object_assertion(mock_s3, awssert):
+def test_s3_bucket_contains_object_assertion(mock_s3):
     bucket = boto3.resource("s3").Bucket("mock")
     bucket.create(CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
     bucket.put_object(Key="foo", Body=b"123")
@@ -20,7 +19,7 @@ def test_s3_bucket_contains_object_assertion(mock_s3, awssert):
     assert bucket.does_not.contain("bar")
 
 
-def test_s3_bucket_empty_assertion(mock_s3, awssert):
+def test_s3_bucket_empty_assertion(mock_s3):
     bucket = boto3.resource("s3").Bucket("mock")
     bucket.create(CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
     assert bucket.should_be.empty()
@@ -28,7 +27,7 @@ def test_s3_bucket_empty_assertion(mock_s3, awssert):
     assert bucket.should_not_be.empty()
 
 
-def test_s3_bucket_exists_assertion(mock_s3, awssert):
+def test_s3_bucket_exists_assertion(mock_s3):
     bucket = boto3.resource("s3").Bucket("mock")
     assert bucket.should_not.exist()
     assert bucket.does_not.exist()


### PR DESCRIPTION
Fixes issue #1 by replacing the awssert fixture with a pytest hook. Also updates the flake8 config to check for F811 and F401 again